### PR TITLE
attempt to import handle napoleon from sphinx

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -16,7 +16,11 @@ from typing import get_type_hints as _get_type_hints
 from xml.etree import ElementTree
 
 from docutils.core import publish_doctree
-from sphinxcontrib.napoleon.docstring import GoogleDocstring, NumpyDocstring
+try:
+    from sphinx.ext.napoleon.docstring import GoogleDocstring, NumpyDocstring
+except ImportError:  # pragma: no cover
+    from sphinxcontrib.napoleon.docstring import GoogleDocstring
+    from sphinxcontrib.napoleon.docstring import NumpyDocstring
 
 # The 2.x builtin goes first so we don't get future's builtins if installed
 try:

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -204,6 +204,7 @@ A runnable example is available at `examples/annotations.py`_.
 .. [#] While Napoleon is included with Sphinx as `sphinx.ext.napoleon`, defopt
    depends on ``sphinxcontrib-napoleon`` so that end users of your command line
    tool are not required to install Sphinx and all of its dependencies.
+   However, if Sphinx is installed, defopt can just use that.
 .. [#] `enum` was introduced in Python 3.4. If you are using an older version
    of Python, the backport will be installed as a dependency.
 .. [#] `typing` was introduced in Python 3.5. If you are using an older version


### PR DESCRIPTION
napoleon ships in sphinx 1.4.8 and later. Try to load the newer path first, falling back to the older sphinxcontrib path in case users do not
have sphinx installed.

Fedora has retired the python-sphinxcontrib-napoleon RPM (obsoleted by the main python-sphinx RPM), so this change allows defopt to run on Fedora when using system packages.