### PR TITLE
Automatic short flags

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -11,7 +11,7 @@ import re
 import sys
 from argparse import (SUPPRESS, ArgumentParser, RawTextHelpFormatter,
                       ArgumentDefaultsHelpFormatter)
-from collections import defaultdict, namedtuple, OrderedDict
+from collections import defaultdict, namedtuple, Counter, OrderedDict
 from enum import Enum
 from typing import List, Iterable, Sequence, Union, Callable, Dict
 from typing import get_type_hints as _get_type_hints
@@ -57,13 +57,15 @@ def run(*funcs, **kwargs):
     :type parsers: Dict[type, Callable[[str], type]]
     :param short: Dictionary mapping parameter names (after conversion of
         underscores to dashes) to letters, to use as alternative short flags.
+        Defaults to ``None``, which means to generate short flags for any
+        non-ambiguous option.  Set to ``{}`` to completely disable short flags.
     :type short: Dict[str, str]
     :param List[str] argv: Command line arguments to parse (default:
         sys.argv[1:])
     :return: The value returned by the function that was run
     """
     parsers = kwargs.pop('parsers', None)
-    short = kwargs.pop('short', {})
+    short = kwargs.pop('short', None)
     argv = kwargs.pop('argv', None)
     if kwargs:
         raise TypeError(
@@ -104,20 +106,33 @@ def _populate_parser(func, parser, parsers, short):
     doc = _parse_doc(func)
     hints = _get_type_hints(func)
     parser.description = doc.text
+
+    types = dict((name, _get_type(func, name, doc, hints))
+                 for name, param in sig.parameters.items())
+    positionals = set(name for name, param in sig.parameters.items()
+                      if (param.default == param.empty
+                          and not types[name].container
+                          and param.kind != param.KEYWORD_ONLY))
+    if short is None:
+        count_initials = Counter(name[0] for name in sig.parameters
+                                 if name not in positionals)
+        short = dict(
+            (name.replace('_', '-'), name[0]) for name in sig.parameters
+            if name not in positionals and count_initials[name[0]] == 1)
+
     for name, param in sig.parameters.items():
         kwargs = {}
         if name in doc.params:
             help_ = doc.params[name].text
             if help_ is not None:
                 kwargs['help'] = help_.replace('%', '%%')
-        type_ = _get_type(func, name, doc, hints)
+        type_ = types[name]
         if param.kind == param.VAR_KEYWORD:
             raise ValueError('**kwargs not supported')
         hasdefault = param.default != param.empty
         default = param.default if hasdefault else SUPPRESS
         required = not hasdefault and param.kind != param.VAR_POSITIONAL
-        positional = (not hasdefault and not type_.container
-                      and param.kind != param.KEYWORD_ONLY)
+        positional = name in positionals
         if type_.type == bool and not positional and not type_.container:
             # Special case: just add parameterless --name and --no-name flags.
             group = parser.add_mutually_exclusive_group(required=required)

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -46,8 +46,10 @@ The command line usage will indicate this. ::
 Flags
 -----
 
-Any keyword arguments are converted to flags, with all underscores in the name
-replaced by hyphens. Names of positional arguments are used unmodified::
+Any keyword arguments are converted to flags, with all underscores in
+the name replaced by hyphens. Names of positional arguments are used
+unmodified.  By default, short flags are generated for keyword arguments
+that do not share their initial with other keyword arguments::
 
     usage: test.py [-h] [--keyword-arg KEYWORD_ARG] positional_arg
 
@@ -56,20 +58,23 @@ replaced by hyphens. Names of positional arguments are used unmodified::
 
     optional arguments:
       -h, --help            show this help message and exit
-      --keyword-arg KEYWORD_ARG
+      -k KEYWORD_ARG, --keyword-arg KEYWORD_ARG
 
 In Python 3, any keyword-only arguments without defaults are marked as required.
 
-If you wish to specify that a particular flag should also have an associated
-short version, you can pass a mapping to `defopt.run`::
+You can override these generated short flags by passing a dictionary to
+`defopt.run` which maps flag names to single letters::
 
-    defopt.run(main, short={'keyword-arg': 'k'})
+    defopt.run(main, short={'keyword-arg': 'a'})
 
-Now, ``-k`` is exactly equivalent to ``--keyword-arg``::
+Now, ``-a`` is exactly equivalent to ``--keyword-arg``::
 
-      -k KEYWORD_ARG, --keyword-arg KEYWORD_ARG
+      -a KEYWORD_ARG, --keyword-arg KEYWORD_ARG
 
 A runnable example is available at `examples/short.py`_.
+
+Passing an empty dictionary suppresses automatic short flag generation, without
+adding new flags.
 
 Booleans
 --------

--- a/examples/short.py
+++ b/examples/short.py
@@ -9,7 +9,7 @@ Code usage::
 
 Command line usage::
 
-    $ python short.py -c 2
+    $ python short.py -C 2
     $ python short.py --count 2
 """
 import defopt
@@ -25,4 +25,4 @@ def main(count=1):
 
 
 if __name__ == '__main__':
-    defopt.run(main, short={'count': 'c'})
+    defopt.run(main, short={'count': 'C'})

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -288,6 +288,19 @@ class TestFlags(unittest.TestCase):
         out = defopt.run(func, short={'foo': 'f', 'no-foo': 'F'}, argv=['-F'])
         self.assertIs(out, False)
 
+    def test_auto_short(self):
+        def func(foo=1, bar=2, baz=3):
+            """
+            :type foo: int
+            :type bar: int
+            :type baz: int
+            """
+            return foo
+        out = defopt.run(func, argv=['-f', '2'])
+        self.assertEqual(out, 2)
+        with self.assertRaises(SystemExit):
+            defopt.run(func, argv=['-b', '2'])
+
 
 class TestEnums(unittest.TestCase):
     def test_enum(self):
@@ -742,7 +755,7 @@ class TestExamples(unittest.TestCase):
     def test_short_cli(self):
         output = self._run_example(short, ['--count', '2'])
         self.assertEqual(output, b'hello!\nhello!\n')
-        output = self._run_example(short, ['-c', '2'])
+        output = self._run_example(short, ['-C', '2'])
         self.assertEqual(output, b'hello!\nhello!\n')
 
     @unittest.skipIf(sys.version_info.major == 2, 'print is unpatchable')


### PR DESCRIPTION
See #21.  Note that this PR depends on #20 (the first few commits are from that PR).

Turning off automatic generation of short flags can be achieved by replacing the `short = kwargs.pop('short', None)` line by `short = kwargs.pop('short', {})` (and updating the docs).  But I'd rather keep it on by default.