### PR TITLE
Let `run` take a list of callables as arg.

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -31,10 +31,10 @@ specific types.
 Subcommands
 -----------
 
-If multiple commands are passed to `defopt.run`, they are treated as
+If a list of commands are passed to `defopt.run`, they are treated as
 subcommands which are run by name. ::
 
-    defopt.run(func1, func2)
+    defopt.run([func1, func2])
 
 The command line usage will indicate this. ::
 

--- a/examples/annotations.py
+++ b/examples/annotations.py
@@ -40,4 +40,4 @@ def undocumented(numbers: Iterable[float], exponent: int) -> None:
 
 
 if __name__ == '__main__':
-    defopt.run(documented, undocumented)
+    defopt.run([documented, undocumented])

--- a/examples/starargs.py
+++ b/examples/starargs.py
@@ -42,4 +42,4 @@ def iterable(*groups):
 
 
 if __name__ == '__main__':
-    defopt.run(plain, iterable)
+    defopt.run([plain, iterable])

--- a/examples/styles.py
+++ b/examples/styles.py
@@ -98,4 +98,4 @@ def numpy(integer, farewell=None):
 
 
 if __name__ == '__main__':
-    defopt.run(sphinx, google, numpy)
+    defopt.run([sphinx, google, numpy])

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -34,6 +34,10 @@ class TestDefopt(unittest.TestCase):
             """:type baz: int"""
             return baz
         self.assertEqual(
+            defopt.run([sub1, sub2], argv=['sub1', '1.1']), (1.1,))
+        self.assertEqual(
+            defopt.run([sub1, sub2], argv=['sub2', '--baz', '1']), 1)
+        self.assertEqual(
             defopt.run(sub1, sub2, argv=['sub1', '1.1']), (1.1,))
         self.assertEqual(
             defopt.run(sub1, sub2, argv=['sub2', '--baz', '1']), 1)
@@ -76,10 +80,6 @@ class TestDefopt(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             defopt.run(bad)
-
-    def test_no_function(self):
-        with self.assertRaisesRegex(ValueError, 'at least one'):
-            defopt.run()
 
     def test_bad_arg(self):
         with self.assertRaises(TypeError):
@@ -323,11 +323,13 @@ class TestEnums(unittest.TestCase):
         def sub1(foo):
             """:type foo: Choice"""
             return foo
-
         def sub2(bar):
             """:type bar: Choice"""
             return bar
-
+        self.assertEqual(
+            defopt.run([sub1, sub2], argv=['sub1', 'one']), Choice.one)
+        self.assertEqual(
+            defopt.run([sub1, sub2], argv=['sub2', 'two']), Choice.two)
         self.assertEqual(
             defopt.run(sub1, sub2, argv=['sub1', 'one']), Choice.one)
         self.assertEqual(
@@ -675,7 +677,7 @@ class TestHelp(unittest.TestCase):
         self.assertNotIn('FOO', self._get_help(foo, bar))
 
     def _get_help(self, *funcs):
-        parser, _ = defopt._create_parser_and_main(*funcs)
+        parser = defopt._create_parser(*funcs)
         return parser.format_help()
 
 


### PR DESCRIPTION
The previous behavior (taking multiple callables as separate args) is
kept with a deprecation warning.  The exception thrown when no
positional argument is passed is changed to TypeError, consistently with
calling a function with arguments not matching the signature.

xref https://github.com/evanunderscore/defopt/pull/26#issuecomment-292702736