### PR TITLE
Add default parser for pathlib.Path.

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -28,6 +28,13 @@ except ImportError:  # pragma: no cover
     from funcsigs import signature as _inspect_signature
 
 try:
+    from pathlib import Path
+except ImportError:
+    class Path(object):
+        """Dummy type, such that no user input is ever of that type.
+        """
+
+try:
     from colorama import colorama_text as _colorama_text
 except ImportError:
     @contextlib.contextmanager
@@ -407,7 +414,7 @@ def _find_parser(type_, parsers):
         return parsers[type_]
     except KeyError:
         pass
-    if type_ in [int, str, float]:
+    if type_ in [int, str, float, Path]:
         return type_
     elif type_ == bool:
         return _parse_bool

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -7,6 +7,11 @@ import typing
 import unittest
 
 try:
+    from pathlib import Path
+except ImportError:
+    Path = None
+
+try:
     from unittest import mock
 except ImportError:
     import mock
@@ -151,6 +156,13 @@ class TestParsers(unittest.TestCase):
         self.assertEqual(parser('1'), True)
         with self.assertRaises(ValueError):
             parser('foo')
+
+    @unittest.skipIf(Path is None, 'pathlib not installed')
+    def test_parse_path(self):
+        def main(value):
+            """:type value: Path"""
+            return value
+        self.assertEqual(defopt.run(main, argv=['foo']), Path('foo'))
 
     def test_no_parser(self):
         with self.assertRaisesRegex(Exception, 'no parser'):


### PR DESCRIPTION
See #28.  This works even if pathlib is not present (except that `_find_parser(None, {})` would now return None instead of raising an error, but I don't think this is a problem?).