### PR TITLE
Improve help formatting.

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -12,7 +12,7 @@ import logging
 import re
 import sys
 import warnings
-from argparse import ArgumentParser, RawTextHelpFormatter
+from argparse import ArgumentParser, RawTextHelpFormatter, _StoreAction
 from collections import defaultdict, namedtuple, Counter, OrderedDict
 from enum import Enum
 from typing import List, Iterable, Sequence, Union, Callable, Dict
@@ -127,7 +127,7 @@ class _Formatter(RawTextHelpFormatter):
         info = []
         if action.type is not None and '%(type)' not in action.help:
             info.append('type: %(type)s')
-        if (type(action).__name__ is '_StoreAction'
+        if (isinstance(action, _StoreAction)
                 and '%(default)' not in action.help
                 and action.default is not argparse.SUPPRESS
                 and action.option_strings):

--- a/defopt.py
+++ b/defopt.py
@@ -120,16 +120,17 @@ def _create_parser(funcs, *args, **kwargs):
 
 class _Formatter(RawTextHelpFormatter):
 
-    # modified from ArgumentDefaultsHelpFormatter to add type information, and
-    # remove defaults for varargs (`ZERO_OR_MORE`).
+    # Modified from ArgumentDefaultsHelpFormatter to add type information,
+    # and remove defaults for varargs (which use _AppendAction instead of
+    # _StoreAction).
     def _get_help_string(self, action):
         info = []
         if action.type is not None and '%(type)' not in action.help:
-            info.append('%(type)s')
-        if (action.default != argparse.SUPPRESS
+            info.append('type: %(type)s')
+        if (type(action).__name__ is '_StoreAction'
                 and '%(default)' not in action.help
-                and action.option_strings
-                and action.nargs != argparse.ZERO_OR_MORE):
+                and action.default is not argparse.SUPPRESS
+                and action.option_strings):
             info.append('default: %(default)s')
         if info:
             return action.help + ' ({})'.format(', '.join(info))
@@ -458,4 +459,5 @@ def _enum_getter(enum):
             return enum[name]
         except KeyError:
             return name
+    getter.__name__ = enum.__name__
     return getter

--- a/defopt.py
+++ b/defopt.py
@@ -5,14 +5,14 @@ Run Python functions from the command line with ``run(func)``.
 from __future__ import (
     absolute_import, division, unicode_literals, print_function)
 
-import argparse
 import contextlib
 import inspect
 import logging
 import re
 import sys
 import warnings
-from argparse import ArgumentParser, RawTextHelpFormatter, _StoreAction
+from argparse import (
+    SUPPRESS, ArgumentParser, RawTextHelpFormatter, _StoreAction)
 from collections import defaultdict, namedtuple, Counter, OrderedDict
 from enum import Enum
 from typing import List, Iterable, Sequence, Union, Callable, Dict
@@ -129,7 +129,7 @@ class _Formatter(RawTextHelpFormatter):
             info.append('type: %(type)s')
         if (isinstance(action, _StoreAction)
                 and '%(default)' not in action.help
-                and action.default is not argparse.SUPPRESS
+                and action.default is not SUPPRESS
                 and action.option_strings):
             info.append('default: %(default)s')
         if info:
@@ -167,7 +167,7 @@ def _populate_parser(func, parser, parsers, short):
         if param.kind == param.VAR_KEYWORD:
             raise ValueError('**kwargs not supported')
         hasdefault = param.default != param.empty
-        default = param.default if hasdefault else argparse.SUPPRESS
+        default = param.default if hasdefault else SUPPRESS
         required = not hasdefault and param.kind != param.VAR_POSITIONAL
         positional = name in positionals
         if type_.type == bool and not positional and not type_.container:

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -606,6 +606,24 @@ class TestHelp(unittest.TestCase):
             return bar
         self.assertIn('(type: int)', self._get_help(foo))
 
+    def test_enum(self):
+        def foo(bar):
+            """:param Choice bar: baz"""
+            return bar
+        self.assertIn('(type: Choice)', self._get_help(foo))
+
+    def test_default(self):
+        def foo(bar=1):
+            """:param int bar: baz"""
+            return bar
+        self.assertIn('(type: int, default: 1)', self._get_help(foo))
+
+    def test_default_list(self):
+        def foo(bar=[]):
+            """:param typing.List[int] bar: baz"""
+            return bar
+        self.assertIn('(type: int, default: [])', self._get_help(foo))
+
     @unittest.skipIf(sys.version_info.major == 2, 'Syntax not supported')
     def test_keyword_only(self):
         globals_ = {}

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -604,7 +604,7 @@ class TestHelp(unittest.TestCase):
         def foo(bar):
             """:param int bar: baz"""
             return bar
-        self.assertIn('(int)', self._get_help(foo))
+        self.assertIn('(type: int)', self._get_help(foo))
 
     @unittest.skipIf(sys.version_info.major == 2, 'Syntax not supported')
     def test_keyword_only(self):

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -600,6 +600,12 @@ class TestTyping(unittest.TestCase):
 
 
 class TestHelp(unittest.TestCase):
+    def test_type(self):
+        def foo(bar):
+            """:param int bar: baz"""
+            return bar
+        self.assertIn('(int)', self._get_help(foo))
+
     @unittest.skipIf(sys.version_info.major == 2, 'Syntax not supported')
     def test_keyword_only(self):
         globals_ = {}
@@ -620,31 +626,17 @@ class TestHelp(unittest.TestCase):
         '''), globals_)
         self.assertNotIn('default', self._get_help(globals_['foo']))
 
-    @unittest.expectedFailure
-    def test_var_positional_desired(self):
+    def test_var_positional(self):
         def foo(*bar):
             """:param int bar: baz"""
             return bar
         self.assertNotIn('default', self._get_help(foo))
 
-    def test_var_positional_actual(self):
-        def foo(*bar):
-            """:param int bar: baz"""
-            return bar
-        self.assertIn('(default: [])', self._get_help(foo))
-
-    @unittest.expectedFailure
-    def test_list_var_positional_desired(self):
+    def test_list_var_positional(self):
         def foo(*bar):
             """:param list[int] bar: baz"""
             return bar
         self.assertNotIn('default', self._get_help(foo))
-
-    def test_list_var_positional_actual(self):
-        def foo(*bar):
-            """:param list[int] bar: baz"""
-            return bar
-        self.assertIn('(default: [])', self._get_help(foo))
 
     def test_no_interpolation(self):
         def foo(bar):


### PR DESCRIPTION
- Display type of arguments.
- Hide default (`[]`) for varargs.

Fixes #10, #19.