### PR TITLE
Update display of types in help text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,13 +52,12 @@ informative help message.
 
     positional arguments:
       greeting              Greeting to display
-                            (type: str)
 
     optional arguments:
       -h, --help            show this help message and exit
       -c COUNT, --count COUNT
                             Number of times to display the greeting
-                            (type: int, default: 1)
+                            (default: 1)
 
 Your function can now be called identically from Python and the command line.
 

--- a/README.rst
+++ b/README.rst
@@ -46,16 +46,19 @@ informative help message.
 ::
 
     $ python test.py -h
-    usage: test.py [-h] [--count COUNT] greeting
+    usage: test.py [-h] [-c COUNT] greeting
 
     Display a friendly greeting.
 
     positional arguments:
-      greeting       Greeting to display
+      greeting              Greeting to display
+                            (type: str)
 
     optional arguments:
-      -h, --help     show this help message and exit
-      --count COUNT  Number of times to display the greeting (default: 1)
+      -h, --help            show this help message and exit
+      -c COUNT, --count COUNT
+                            Number of times to display the greeting
+                            (type: int, default: 1)
 
 Your function can now be called identically from Python and the command line.
 

--- a/defopt.py
+++ b/defopt.py
@@ -12,7 +12,7 @@ import re
 import sys
 import warnings
 from argparse import (
-    SUPPRESS, ArgumentParser, RawTextHelpFormatter, _StoreAction)
+    SUPPRESS, ArgumentParser, RawTextHelpFormatter, _AppendAction)
 from collections import defaultdict, namedtuple, Counter, OrderedDict
 from enum import Enum
 from typing import List, Iterable, Sequence, Union, Callable, Dict
@@ -134,13 +134,13 @@ class _Formatter(RawTextHelpFormatter):
         info = []
         if action.type is not None and '%(type)' not in action.help:
             info.append('type: %(type)s')
-        if (isinstance(action, _StoreAction)
+        if (not isinstance(action, _AppendAction)
                 and '%(default)' not in action.help
                 and action.default is not SUPPRESS
                 and action.option_strings):
             info.append('default: %(default)s')
         if info:
-            return action.help + ' ({})'.format(', '.join(info))
+            return action.help + '\n({})'.format(', '.join(info))
         else:
             return action.help
 

--- a/defopt.py
+++ b/defopt.py
@@ -66,7 +66,7 @@ _Type = namedtuple('_Type', ('type', 'container'))
 
 
 def run(funcs, *args, **kwargs):
-    """run(funcs, *, parsers=None, short=None, argv=None)
+    """run(funcs, *, parsers=None, short=None, show_types=False, argv=None)
 
     Process command line arguments and run the given functions.
 
@@ -83,6 +83,8 @@ def run(funcs, *args, **kwargs):
         Defaults to ``None``, which means to generate short flags for any
         non-ambiguous option.  Set to ``{}`` to completely disable short flags.
     :type short: Dict[str, str]
+    :param bool show_types: If `True`, display type names after parameter
+        descriptions in the the help text.
     :param List[str] argv: Command line arguments to parse (default:
         sys.argv[1:])
     :return: The value returned by the function that was run
@@ -102,6 +104,7 @@ def run(funcs, *args, **kwargs):
 def _create_parser(funcs, *args, **kwargs):
     parsers = kwargs.pop('parsers', None)
     short = kwargs.pop('short', None)
+    show_types = kwargs.pop('show_types', False)
     if kwargs:
         raise TypeError(
             'unexpected keyword argument: {}'.format(list(kwargs)[0]))
@@ -110,7 +113,10 @@ def _create_parser(funcs, *args, **kwargs):
             'Passing multiple functions as separate arguments is deprecated; '
             'pass a list of functions instead', DeprecationWarning)
         funcs = [funcs] + list(args)
-    parser = ArgumentParser(formatter_class=_Formatter)
+    formatter_class = _NoTypeFormatter
+    if show_types:
+        formatter_class = _Formatter
+    parser = ArgumentParser(formatter_class=formatter_class)
     if callable(funcs):
         _populate_parser(funcs, parser, parsers, short)
         parser.set_defaults(_func=funcs)
@@ -118,7 +124,7 @@ def _create_parser(funcs, *args, **kwargs):
         subparsers = parser.add_subparsers()
         for func in funcs:
             subparser = subparsers.add_parser(
-                func.__name__, formatter_class=_Formatter,
+                func.__name__, formatter_class=formatter_class,
                 help=_parse_function_docstring(func).paragraphs[0])
             _populate_parser(func, subparser, parsers, short)
             subparser.set_defaults(_func=func)
@@ -126,14 +132,16 @@ def _create_parser(funcs, *args, **kwargs):
 
 
 class _Formatter(RawTextHelpFormatter):
+    show_types = True
 
     # Modified from ArgumentDefaultsHelpFormatter to add type information,
     # and remove defaults for varargs (which use _AppendAction instead of
     # _StoreAction).
     def _get_help_string(self, action):
         info = []
-        if action.type is not None and '%(type)' not in action.help:
-            info.append('type: %(type)s')
+        if self.show_types:
+            if action.type is not None and '%(type)' not in action.help:
+                info.append('type: %(type)s')
         if (not isinstance(action, _AppendAction)
                 and '%(default)' not in action.help
                 and action.default is not SUPPRESS
@@ -143,6 +151,10 @@ class _Formatter(RawTextHelpFormatter):
             return action.help + '\n({})'.format(', '.join(info))
         else:
             return action.help
+
+
+class _NoTypeFormatter(_Formatter):
+    show_types = False
 
 
 def _populate_parser(func, parser, parsers, short):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,9 +1,7 @@
 API Reference
 =============
 
-.. Listing `run` because we don't want to show the `parsers` stub.
-
 .. automodule:: defopt
-    :members: run
+    :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -83,7 +83,8 @@ Boolean keyword arguments are automatically converted to two separate flags:
 ``--name`` which stores `True` and ``--no-name`` which stores `False`. Your
 help text and the default will be displayed next to the ``--name`` flag::
 
-    --flag      Set "flag" to True (default: False)
+    --flag      Set "flag" to True
+                (default: False)
     --no-flag
 
 Note that this does not apply to mandatory boolean arguments; these must be
@@ -116,6 +117,7 @@ handled specially on the command line to produce more helpful output. ::
 
     positional arguments:
       {red,blue,yellow}  Your favorite color
+                         (type: Color)
 
 This also produces a more helpful message when you choose an invalid option. ::
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -28,6 +28,9 @@ Argument types are read from your function's docstring. Both
 called. See Booleans_, Lists_, Choices_ and Parsers_ for more information on
 specific types.
 
+Type information can be automatically added to the help text by passing
+``show_types=True`` to `defopt.run`.
+
 Subcommands
 -----------
 
@@ -117,7 +120,6 @@ handled specially on the command line to produce more helpful output. ::
 
     positional arguments:
       {red,blue,yellow}  Your favorite color
-                         (type: Color)
 
 This also produces a more helpful message when you choose an invalid option. ::
 

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -704,8 +704,16 @@ class TestHelp(unittest.TestCase):
         self.assertIn('foo', self._get_help(foo, bar))
         self.assertNotIn('FOO', self._get_help(foo, bar))
 
-    def _get_help(self, *funcs):
-        parser = defopt._create_parser(*funcs)
+    def test_hide_types(self):
+        def foo(bar):
+            """:param int bar: baz"""
+            return bar
+        self.assertNotIn('type', self._get_help(foo, show_types=False))
+
+    def _get_help(self, *funcs, **kwargs):
+        show_types = kwargs.pop('show_types', True)
+        assert not kwargs
+        parser = defopt._create_parser(*funcs, show_types=show_types)
         return parser.format_help()
 
 

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -636,6 +636,12 @@ class TestHelp(unittest.TestCase):
             return bar
         self.assertIn('(type: int, default: [])', self._get_help(foo))
 
+    def test_default_bool(self):
+        def foo(bar=False):
+            """:param bool bar: baz"""
+            return bar
+        self.assertIn('(default: False)', self._get_help(foo))
+
     @unittest.skipIf(sys.version_info.major == 2, 'Syntax not supported')
     def test_keyword_only(self):
         globals_ = {}


### PR DESCRIPTION
The types and defaults are now displayed on a separate line.
This prevents the last line from getting unreasonably long
(since we're using the raw text formatter) and makes it easier
to spot type information when reading the help text.

Defaults are added for all action types except _AppendAction.
This restores the default display for boolean flags.

Examples in the documentation have been updated.