### PR TITLE
Ignore args whose name start with an underscore.

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -158,7 +158,10 @@ class _NoTypeFormatter(_Formatter):
 
 
 def _populate_parser(func, parser, parsers, short):
-    sig = _inspect_signature(func)
+    full_sig = _inspect_signature(func)
+    sig = full_sig.replace(
+        parameters=list(param for param in full_sig.parameters.values()
+                        if not param.name.startswith('_')))
     doc = _parse_function_docstring(func)
     hints = _get_type_hints(func)
     parser.description = doc.text

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -170,6 +170,11 @@ Variable keyword arguments (``**kwargs``) are not supported.
 
 A runnable example is available at `examples/starargs.py`_.
 
+Private Arguments
+-----------------
+
+Arguments whose name start with an underscore will not be added to the parser.
+
 Entry Points
 ------------
 

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -674,6 +674,11 @@ class TestHelp(unittest.TestCase):
             return bar
         self.assertNotIn('default', self._get_help(foo))
 
+    def test_private(self):
+        def foo(bar, _baz=None):
+            """:param int bar: bar help"""
+        self.assertNotIn('baz', self._get_help(foo))
+
     def test_no_interpolation(self):
         def foo(bar):
             """:param int bar: %(prog)s"""


### PR DESCRIPTION
See #34.