### PR TITLE
Define defopt.__all__.

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -49,6 +49,7 @@ if sys.version_info.major == 2:  # pragma: no cover
 else:
     _basestring = str
 
+__all__ = ['run']
 __version__ = '3.2.0'
 
 _LIST_TYPES = [List, Iterable, Sequence]


### PR DESCRIPTION
All's in the title (pun intended).

Note that this makes `pydoc defopt` much cleaner.