### PR TITLE
Replace underscores by dashes in subcommand names.

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -133,7 +133,8 @@ def _create_parser(funcs, *args, **kwargs):
         subparsers = parser.add_subparsers()
         for func in funcs:
             subparser = subparsers.add_parser(
-                func.__name__, formatter_class=formatter_class,
+                func.__name__.replace("_", "-"),
+                formatter_class=formatter_class,
                 help=_parse_function_docstring(func).paragraphs[0])
             _populate_parser(func, subparser, parsers, short, strict_kwonly)
             subparser.set_defaults(_func=func)

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -46,6 +46,8 @@ The command line usage will indicate this. ::
     positional arguments:
       {func1,func2}
 
+Underscores in function names are replaced by hyphens.
+
 Flags
 -----
 

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -41,22 +41,22 @@ class TestDefopt(unittest.TestCase):
         self.assertEqual(defopt.run(main, argv=['foo']), 'foo')
 
     def test_subcommands(self):
-        def sub1(*bar):
+        def sub(*bar):
             """:type bar: float"""
             return bar
-        def sub2(baz=None):
+        def sub_with_dash(baz=None):
             """:type baz: int"""
             return baz
         self.assertEqual(
-            defopt.run([sub1, sub2], argv=['sub1', '1.1']), (1.1,))
+            defopt.run([sub, sub_with_dash], argv=['sub', '1.1']), (1.1,))
         self.assertEqual(
-            defopt.run([sub1, sub2], strict_kwonly=False,
-                       argv=['sub2', '--baz', '1']), 1)
+            defopt.run([sub, sub_with_dash], strict_kwonly=False,
+                       argv=['sub-with-dash', '--baz', '1']), 1)
         self.assertEqual(
-            defopt.run(sub1, sub2, argv=['sub1', '1.1']), (1.1,))
+            defopt.run(sub, sub_with_dash, argv=['sub', '1.1']), (1.1,))
         self.assertEqual(
-            defopt.run(sub1, sub2, strict_kwonly=False,
-                       argv=['sub2', '--baz', '1']), 1)
+            defopt.run(sub, sub_with_dash, strict_kwonly=False,
+                       argv=['sub-with-dash', '--baz', '1']), 1)
 
     def test_var_positional(self):
         def main(*foo):


### PR DESCRIPTION
Note that if one of the subcommand functions has a name starting with an
underscore, an invalid parser will be generated, as the corresponding
subcommand will start with a dash and thus not be triggerable from the
command line.  However, I consider that it should be up to argparse to
raise an exception in that case -- if it doesn't do that validation, we
shouldn't bother either.

xref #44.