### PR TITLE
Support bullet lists

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -522,7 +522,10 @@ def _parse_docstring(doc):
                 visitor.paragraphs,
                 visitor.start_lines[1:] + [0]):
             text.append(paragraph)
-            text.append('\n' * (next_start - start - paragraph.count('\n')))
+            # We insert a space before each newline to prevent argparse
+            # from stripping consecutive newlines down to just two
+            # (http://bugs.python.org/issue31330).
+            text.append(' \n' * (next_start - start - paragraph.count('\n')))
         parsed = _Doc('', ''.join(text), tuples)
     else:
         parsed = _Doc('', '', tuples)

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -600,16 +600,38 @@ class TestDoc(unittest.TestCase):
         doc = defopt._parse_function_docstring(func)
         self.assertEqual(doc.text, '    Literal block\n        Multiple lines')
 
-    def test_bullet_list(self):
+    def test_newlines(self):
         def func():
             """
-            - foo
+            Bar
+            Baz
+
             - bar
-            - i.  quux
-              ii. blah
+            - baz
+
+            quux::
+
+                hello
+
+            1. bar
+
+            2. baz
             """
         doc = defopt._parse_function_docstring(func)
-        self.assertEqual(doc.text, '- foo\n\n- bar\n\n- i.  quux\n\n  ii. blah')
+        self.assertEqual(doc.text, """\
+Bar
+Baz
+
+- bar
+- baz
+
+quux:
+
+    hello
+
+1. bar
+
+2. baz""")
 
 
 class TestAnnotations(unittest.TestCase):

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -605,11 +605,11 @@ class TestDoc(unittest.TestCase):
             """
             - foo
             - bar
-            - * quux
-              * blah
+            - i.  quux
+              ii. blah
             """
         doc = defopt._parse_function_docstring(func)
-        self.assertEqual(doc.text, '- foo\n\n- bar\n\n- * quux\n\n  * blah')
+        self.assertEqual(doc.text, '- foo\n\n- bar\n\n- i.  quux\n\n  ii. blah')
 
 
 class TestAnnotations(unittest.TestCase):

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 from collections import namedtuple
 from enum import Enum
+import inspect
 import subprocess
 import sys
 import textwrap
@@ -564,7 +565,7 @@ class TestDoc(unittest.TestCase):
 
     def _check_doc(self, doc):
         self.assertEqual(
-            doc.text, 'One line summary.\n\nExtended description.')
+            doc.text, 'One line summary. \n \nExtended description.')
         self.assertEqual(len(doc.params), 3)
         self.assertEqual(doc.params['arg1'].text, 'Description of arg1')
         self.assertEqual(doc.params['arg1'].type, 'int')
@@ -613,25 +614,30 @@ class TestDoc(unittest.TestCase):
 
                 hello
 
+
             1. bar
 
             2. baz
             """
         doc = defopt._parse_function_docstring(func)
-        self.assertEqual(doc.text, """\
-Bar
-Baz
-
-- bar
-- baz
-
-quux:
-
-    hello
-
-1. bar
-
-2. baz""")
+        # Use inspect.cleandoc and not textwrap.dedent, as we want to keep
+        # whitespace in lines that contain more than the common leading
+        # whitespace.
+        self.assertEqual(doc.text, inspect.cleandoc("""\
+            Bar
+            Baz 
+             
+            - bar 
+            - baz 
+             
+            quux: 
+             
+                hello 
+             
+             
+            1. bar 
+             
+            2. baz"""))
 
 
 class TestAnnotations(unittest.TestCase):

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -600,6 +600,17 @@ class TestDoc(unittest.TestCase):
         doc = defopt._parse_function_docstring(func)
         self.assertEqual(doc.text, '    Literal block\n        Multiple lines')
 
+    def test_bullet_list(self):
+        def func():
+            """
+            - foo
+            - bar
+            - * quux
+              * blah
+            """
+        doc = defopt._parse_function_docstring(func)
+        self.assertEqual(doc.text, '- foo\n\n- bar\n\n- * quux\n\n  * blah')
+
 
 class TestAnnotations(unittest.TestCase):
     def test_simple(self):


### PR DESCRIPTION
The first commit reimplements the docstring handler to use a NodeVisitor.
The second commit adds support for bullet lists (#45).

Enumerated lists not implemented yet mostly because they're a pain as you need to handle all kinds of enumeration types (integer, alphabetic, roman) but can basically be implemented with a similar approach.