### PR TITLE
Fix closure over type.

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -247,7 +247,8 @@ def _populate_parser(func, parser, parsers, short, strict_kwonly):
                                  for field in type_.type._fields)
             kwargs['nargs'] = len(member_types)
             kwargs['action'] = _make_store_tuple_action_class(
-                lambda args: type_.type(*args), member_types, parsers)
+                lambda args, type_=type_: type_.type(*args),
+                member_types, parsers)
             if not positional:  # http://bugs.python.org/issue14074
                 kwargs['metavar'] = type_.type._fields
         elif inspect.isclass(type_.type) and issubclass(type_.type, Enum):

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -401,12 +401,17 @@ class TestTuple(unittest.TestCase):
         self.assertEqual(defopt.run(main, argv=['1', '2']), (1, '2'))
 
     def test_namedtuple(self):
-        def main(foo):
-            """:param Pair foo: foo"""
+        # Add a second argument after the tuple to ensure that the converter
+        # closes over the correct type.
+        def main(foo, bar):
+            """
+            :param Pair foo: foo
+            :param int bar: bar
+            """
             return foo
         # Instances of the Pair class compare equal to tuples, so we compare
         # their __str__ instead to make sure that the type is correct too.
-        self.assertEqual(str(defopt.run(main, argv=['1', '2'])),
+        self.assertEqual(str(defopt.run(main, argv=['1', '2', '3'])),
                          str(Pair(1, '2')))
 
 


### PR DESCRIPTION
Otherwise, something like
```
from typing import NamedTuple
import defopt

class T(NamedTuple):
    x: str; y: str

@defopt.run
def main(p: T, q: int):
    print(p)
```
crashes because `type_` changes in the closure.

Sorry I missed that.  I don't have the time to write a test right now, but can probably do so some time later, or feel free to take over the PR if you have time to.