### PR TITLE
Support passing --foo --no-foo with the later flag winning.

### DIFF
--- a/test_defopt.py
+++ b/test_defopt.py
@@ -280,19 +280,11 @@ class TestParsers(unittest.TestCase):
             """:type foo: bool"""
             return foo
         self.assertIs(defopt.run(main, strict_kwonly=False,
+                                 argv=[]), default)
+        self.assertIs(defopt.run(main, strict_kwonly=False,
                                  argv=['--foo']), True)
         self.assertIs(defopt.run(main, strict_kwonly=False,
                                  argv=['--no-foo']), False)
-        self.assertIs(defopt.run(main, strict_kwonly=False,
-                                 argv=[]), default)
-
-    @unittest.skipIf(sys.version_info < (3, 4),
-                     'expectedFailure ignores SystemExit')
-    @unittest.expectedFailure
-    def test_bool_kwarg_override(self):
-        def main(foo=True):
-            """:type foo: bool"""
-            return foo
         self.assertIs(defopt.run(main, strict_kwonly=False,
                                  argv=['--foo', '--no-foo']), False)
 


### PR DESCRIPTION
This had been marked as expectedFailure in the tests probably because of
the lack of "required, but non-mutually-exclusive group" support in
argparse.  Work around that with a manual implemetation.