### PR TITLE
Fix Py3.7 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
+dist: xenial
+sudo: true
 language: python
 python:
   - 2.7
   - 3.4
   - 3.5
   - 3.6
-  - 3.7-dev
+  - 3.7
+  - 3.8-dev
 matrix:
   allow_failures:
-    - python: 3.7-dev
+    - python: 3.8-dev
 install:
   - pip install --upgrade pip setuptools coverage
   - pip install .

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=[
         'docutils',
         'sphinxcontrib-napoleon>=0.5.1',
+        'typing_inspect>=0.3.1',
     ],
     extras_require={
         ':python_version<"3.3"': ['funcsigs'],
@@ -38,6 +39,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: OS Independent',
         'Development Status :: 5 - Production/Stable',

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -685,16 +685,6 @@ class TestAnnotations(unittest.TestCase):
         self.assertEqual(defopt.run(globals_['foo'], argv=['1']), 1)
 
 
-class TestTyping(unittest.TestCase):
-    def test_old_union(self):
-        union = mock.Mock()
-        self.assertFalse(defopt._is_generic_type(union, typing.Union))
-        union.__union_params__ = []
-        self.assertFalse(defopt._is_generic_type(union, typing.Union))
-        union.__union_params__ = [int]
-        self.assertTrue(defopt._is_generic_type(union, typing.Union))
-
-
 class TestHelp(unittest.TestCase):
     def test_type(self):
         def foo(bar):


### PR DESCRIPTION
The typing "internal" API is changing quickly, so rely on the
semi-official typing_inspect module to handle that.

Closes #57.

Failure is for Py3.3, handled by #58.