### PR TITLE
Allow customization of ArgumentParser construction.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+next
+----
+* Added ``argparse_kwargs``.
+
 5.0.0 (2018-10-18)
 ------------------
 * Added default parser for ``slice``.

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -147,13 +147,22 @@ class TestDefopt(unittest.TestCase):
             """
             return a_b_c, d_e_f
         self.assertEqual(
-            defopt.run(main, strict_kwonly=False,
-                       argv=['1', '--d-e-f', '2']), (1, 2))
+            defopt.run(main, strict_kwonly=False, argv=['1', '--d-e-f', '2']),
+            (1, 2))
 
     def test_private_with_default(self):
         def main(_a=None):
             pass
         defopt.run(main, argv=[])
+
+    def test_argparse_kwargs(self):
+        def main(a=None):
+            """:type a: str"""
+            return a
+        self.assertEqual(
+            defopt.run(main, strict_kwonly=False,
+                       argparse_kwargs={'prefix_chars': '+'}, argv=['+a', 'foo']),
+            'foo')
 
 
 class TestParsers(unittest.TestCase):


### PR DESCRIPTION
Fixes part of #35.
(The hack I proposed in https://github.com/evanunderscore/defopt/issues/35#issuecomment-307604480 doesn't work at least as of Py3.7 because argparse tries to call `super(ArgumentParser, self)` which fails if ArgumentParser is patched to not be a class anymore.)

Also helps with #7 (a similar use case prompted me to write this PR): one can now use the https://docs.python.org/3/library/argparse.html#fromfile-prefix-chars feature of argparse to load the arguments from a file (perhaps it could be useful to also make https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.convert_arg_line_to_args overriddable from defopt, and that should then cover most cases, but let's not get ahead of ourselves...).