### PR TITLE
Fix subcommand summary help.

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -536,7 +536,7 @@ def _parse_docstring(doc):
             # from stripping consecutive newlines down to just two
             # (http://bugs.python.org/issue31330).
             text.append(' \n' * (next_start - start - paragraph.count('\n')))
-        parsed = _Doc('', ''.join(text), tuples)
+        parsed = _Doc(text[0], ''.join(text), tuples)
     else:
         parsed = _Doc('', '', tuples)
     _parse_docstring_cache[_cache_key] = parsed

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -832,16 +832,16 @@ class TestHelp(unittest.TestCase):
 
     def test_multiple(self):
         def foo():
-            """foo
+            """summary-of-foo
 
             Implements FOO.
             """
 
         def bar():
-            """bar
+            """summary-of-bar
 
             Implements BAR."""
-        self.assertIn('foo', self._get_help([foo, bar]))
+        self.assertIn('summary-of-foo', self._get_help([foo, bar]))
         self.assertNotIn('FOO', self._get_help([foo, bar]))
 
     def test_hide_types(self):


### PR DESCRIPTION
Previously subcommand help would not display the first line of the
docstring.  The test was incorrect because it checked whether "foo" was
in
```
usage: python -m unittest [-h] {foo,bar} ...

positional arguments:
  {foo,bar}
    foo
    bar

optional arguments:
  -h, --help  show this help message and exit

```
but of course "foo" is present, but as the command name itself.  Change
by checking for another substring.

Looks like I accidentally broke this in #47.