### PR TITLE
Suppress traceback for exceptions listed with :raises:.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 next
 ----
 * Added support for Union types.
+* Added support for catching exceptions.
 
 5.1.0 (2019-03-01)
 ------------------

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -296,6 +296,19 @@ for a parameter is given in both, they must be the same.
 
 A runnable example is available at `examples/annotations.py`_.
 
+Exceptions
+----------
+
+Exception types can also be listed in the function's docstring, with ::
+
+    :raises <type>: <description>
+
+If the function call raises an exception whose type is mentioned in such a
+``:raises:`` clause, the exception message is printed and the program exits
+with status code 1, but the traceback is suppressed.
+
+A runnable example is available at `examples/exceptions.py`_.
+
 .. _Sphinx: http://www.sphinx-doc.org/en/stable/domains.html#info-field-lists
 .. _Google: http://google.github.io/styleguide/pyguide.html
 .. _Numpy: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt

--- a/examples/exceptions.py
+++ b/examples/exceptions.py
@@ -1,0 +1,19 @@
+"""Example showing exception handling.
+
+If the function raises an exception listed in the docstring using :raises:, the
+traceback is suppressed.
+"""
+import defopt
+
+
+def main(arg):
+    """
+    :param int arg: Don't set this to zero!
+    :raises ValueError: If *arg* is zero.
+    """
+    if arg == 0:
+        raise ValueError("Don't do this!")
+
+
+if __name__ == "__main__":
+    defopt.run(main)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=[
         'docutils',
-        'sphinxcontrib-napoleon>=0.5.1',
+        'sphinxcontrib-napoleon>=0.7.0',
         'typing_inspect>=0.3.1',
     ],
     extras_require={


### PR DESCRIPTION
See new example and documentation.

I chose to ignore the message regarding the exception in the docstring
(if any) as it would typically read less nicely (":raises FooError: if
bar" => "if bar").

I don't *actually* test that the traceback is suppressed because that
traceback is generated when the exception causes terminal unwinding of
the interpreter, so that's a bit of a pain to check unless running a
subprocess.

I bumped the napoleon dependency to 0.7 as that's needed for proper
handling of Raises block in numpydoc format (https://github.com/sphinx-contrib/napoleon/commit/beea4d12f7c9457ee7b01df28cf75543423d23cf / https://github.com/sphinx-doc/sphinx/pull/4046).

Closes (mostly) #4 (except perhaps for what to do with the exception docstring).