### PR TITLE
Assume that classes with signature (...: str) are their own parsers.

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -205,6 +205,25 @@ You can now build ``Person`` objects directly from the command line. ::
 
 A runnable example is available at `examples/parsers.py`_.
 
+If the type of an annotation can be called with a single parameter and that
+parameter is annotated as `str`, then `defopt` will assume that the type is
+its own parser.
+
+.. code-block:: python
+
+    class StrWrapper:
+        def __init__(self, s: str):
+            self.s = s
+
+    def main(s: StrWrapper):
+        pass
+
+    defopt.run(main)
+
+You can now build ``StrWrapper`` objects directly from the command line. ::
+
+    test.py foo
+
 Variable Positional Arguments
 -----------------------------
 

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -34,6 +34,17 @@ class Choice(Enum):
 Pair = typing.NamedTuple('Pair', [('first', int), ('second', str)])
 
 
+class ConstructibleFromStr(object):
+    def __init__(self, s):
+        """:type s: str"""
+        self.s = s
+
+
+class NotConstructibleFromStr(object):
+    def __init__(self, s):
+        pass
+
+
 class TestDefopt(unittest.TestCase):
     def test_main(self):
         def main(foo):
@@ -318,6 +329,20 @@ class TestParsers(unittest.TestCase):
         self.assertIs(defopt.run(main, argv=['--no-foo']), False)
         with self.assertRaises(SystemExit):
             defopt.run(main, argv=[])
+
+    def test_implicit_parser(self):
+        def ok(foo):
+            """:type foo: ConstructibleFromStr"""
+            return foo
+
+        self.assertEqual(defopt.run(ok, argv=["foo"]).s, "foo")
+
+    def test_implicit_noparser(self):
+        def notok(foo):
+            """:type foo: NotConstructibleFromStr"""
+
+        with self.assertRaises(Exception):
+            defopt.run(notok, argv=["foo"])
 
 
 class TestFlags(unittest.TestCase):


### PR DESCRIPTION
(More precisely, classes that can be constructed with a single parameter
that's moreover annotated as str.)

Implements the "implicit parser" part of https://github.com/evanunderscore/defopt/issues/69#issuecomment-508922990.