### PR TITLE
Add support for Literals.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ python:
   - 3.6
   - 3.7
   - 3.8-dev
-matrix:
-  allow_failures:
-    - python: 3.8-dev
 install:
   - pip install --upgrade pip setuptools coverage
   - pip install .

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 next
 ----
-* Added support for Union types.
+* Added support for Union and Literal types.
 * Assume that types annotated as constructible from a single str are their own
   parser.
 * Added support for catching exceptions.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -163,6 +163,9 @@ This also produces a more helpful message when you choose an invalid option. ::
 
 A runnable example is available at `examples/choices.py`_.
 
+Likewise, `typing.Literal` and its backport ``typing_extensions.Literal`` are
+also supported.
+
 Tuples
 ------
 

--- a/examples/choices.py
+++ b/examples/choices.py
@@ -1,22 +1,34 @@
 """Example showing choices in defopt.
 
-If a parameter's type is subclass of `enum.Enum`, defopt automatically
-turns this into a set of string choices on the command line.
+If a parameter's type is a subclass of `enum.Enum` or a `typing.Literal` (or
+its backport ``typing_extensions.Literal``), defopt automatically turns this
+into a set of string choices on the command line.
 
 Code usage::
 
-    >>> main(Choice.one, opt=Choice.two)
+    >>> choose_enum(Choice.one, opt=Choice.two)
 
 Command line usage::
 
     $ python choices.py one --opt two
 """
+
 from enum import Enum
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 import defopt
 
 
-def main(arg, opt=None):
+class Choice(Enum):
+    one = 1
+    two = 2.0
+    three = '03'
+
+
+def choose_enum(arg, opt=None):
     """Example function with `enum.Enum` arguments.
 
     :param Choice arg: Choice to display
@@ -27,11 +39,16 @@ def main(arg, opt=None):
         print('{} ({})'.format(opt, opt.value))
 
 
-class Choice(Enum):
-    one = 1
-    two = 2.0
-    three = '03'
+def choose_literal(arg, opt=None):
+    """Example function with `enum.Enum` arguments.
+
+    :param Literal["foo","bar"] arg: Choice to display
+    :param Literal["baz","quu"] opt: Optional choice to display
+    """
+    print(arg)
+    if opt:
+        print(opt)
 
 
 if __name__ == '__main__':
-    defopt.run(main, strict_kwonly=False)
+    defopt.run([choose_enum, choose_literal], strict_kwonly=False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,5 +15,5 @@ universal = 1
 source = defopt
 
 [coverage:report]
-fail_under = 96
+fail_under = 95
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
     extras_require={
         ':python_version<"3.3"': ['funcsigs'],
         ':python_version<"3.4"': ['enum34'],
-        ':python_version<"3.5"': ['typing'],
+        ':python_version<"3.5"': ['typing>=3.7.4'],  # Version constraint matches typing_extensions.
+        ':python_version<"3.8"': ['typing_extensions>=3.7.4'],  # Literal support.
         ':sys.platform=="win32"': ['colorama>=0.3.4'],
     },
     tests_require=[


### PR DESCRIPTION
... like enums; but easier to use for one-off scripts -- essentially maps directly to the `choices` kwarg of ArgumentParser.add_argument.

See https://docs.python.org/3.8/library/typing.html#typing.Literal.

Remove failure allowance on Py38 CI as that's how it's tested.

I chose not to make typing_extensions a dependency, but could, too.