### PR TITLE
bug: StrEnum doesn't support optional

### DIFF
--- a/test_defopt.py
+++ b/test_defopt.py
@@ -13,7 +13,7 @@ import typing
 import unittest
 from concurrent.futures import ProcessPoolExecutor
 from contextlib import ExitStack
-from enum import Enum
+from enum import Enum, StrEnum, auto
 from io import StringIO
 from pathlib import Path
 
@@ -28,6 +28,7 @@ from examples import (
 
 Choice = Enum('Choice', [('one', 1), ('two', 2), ('%', 0.01)])
 Pair = typing.NamedTuple('Pair', [('first', int), ('second', str)])
+StrChoice = StrEnum('StrChoice', [('A', auto()), ('B', auto())])
 
 
 def _parse_none(i):
@@ -643,6 +644,18 @@ class TestEnums(unittest.TestCase):
         self.assertEqual(defopt.run(main, argv=['two']), Choice.two)
         with self.assertRaises(SystemExit):
             defopt.run(main, argv=['three'])
+
+    def test_str_enum(self):
+        def main(*, a: StrChoice) -> None:
+            """:type a: StrChoice"""
+            return a
+        self.assertEqual(defopt.run(main, argv=['--a', 'A']), StrChoice.A)
+    
+    def test_str_enum_optional(self):
+        def main(*, a: StrChoice = StrChoice.A) -> None:
+            """:type a: StrChoice"""
+            return a
+        self.assertEqual(defopt.run(main, argv=[]), StrChoice.A)
 
     def test_optional(self):
         def main(*, foo=None):


### PR DESCRIPTION
The new `test_str_enum_optional` unit test fails when the default value is set to `StrChoice.A` but passes when the default value is set to `"A"`.  I was expecting the former to work, not the latter.  CC: @geoffjentry